### PR TITLE
Fix the failure of Travis building

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ keep_files:  ['.git']
 site: http://shruby.github.io
 url: http://shruby.github.io
 description: 'Web site of ShRuby.github.io'
+exclude: ["vendor"]
 
 save: true
 lsi: false


### PR DESCRIPTION
Got "Post 0000-00-00-welcome-to-jekyll.markdown.erb does not have a valid date." Error when build by Travis. Fix it.
